### PR TITLE
Treat --watch and --server as boolean options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ var argv = require('minimist')(process.argv.slice(2), {alias: {
   'w': 'watch',
   'o': 'output',
   'h': 'help'
-}})
+}, boolean: ['server', 'watch']})
 
 if (!argv._.length || argv.help) {
   var usage = '' +


### PR DESCRIPTION
```
$ github-markdown-preview README.md -s
```

works but

```
$ github-markdown-preview -s README.md
```

doesn't. This patch fixes that.
