### PR TITLE
Wait for generated HTML before starting up a server

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,13 +37,11 @@ if (argv.server) {
     .watch(markdownPath, {persistent: true})
     .on('change', updateServerHTML)
 
-  server.listen(9999)
-
-  console.log('Preview now being served at http://localhost:9999')
-
-  opn('http://localhost:9999')
-
-  return updateServerHTML()
+  return updateServerHTML(function() {
+    server.listen(9999)
+    console.log('Preview now being served at http://localhost:9999')
+    opn('http://localhost:9999')
+  })
 }
 
 if (argv.watch) {
@@ -67,8 +65,9 @@ function logHTML() {
   })
 }
 
-function updateServerHTML() {
+function updateServerHTML(cb) {
   generateHTML(function(err, html) {
     server.update(html)
+    if (cb) cb()
   })
 }

--- a/cli.js
+++ b/cli.js
@@ -68,6 +68,6 @@ function logHTML() {
 function updateServerHTML(cb) {
   generateHTML(function(err, html) {
     server.update(html)
-    if (cb) cb()
+    if (typeof cb == 'function') cb()
   })
 }


### PR DESCRIPTION
Sometimes I get this error:

```
$ github-markdown-preview README.md -s
Preview now being served at http://localhost:9999
.../node_modules/sse-stream/lib/client.js:40
    + data.split('\n').join('\n'+this.data_header)+'\n\n'
          ^
TypeError: Cannot read property 'split' of undefined
    at Client.proto.write (.../node_modules/sse-stream/lib/client.js:40:11)
    at Server.<anonymous> (.../server.js:15:10)
    at emitOne (events.js:77:13)
    at Server.emit (events.js:166:7)
    at Server.proto.handle (.../node_modules/sse-stream/lib/server.js:84:8)
    at Server.on_request (.../node_modules/sse-stream/lib/server.js:58:17)
    at emitTwo (events.js:87:13)
    at Server.emit (events.js:169:7)
    at HTTPParser.parserOnIncoming [as onIncoming] (_http_server.js:471:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:88:23)
    at Socket.socketOnData (_http_server.js:322:22)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:166:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:109:10)
    at TCP.onread (net.js:517:20)
```

AFAIU it is server not being able to write `undefined` html before it received an update.

This patch fixes that by adding an optional callback to `updateServerHTML` and delaying `server.listen` until server is initialized.
