### PR TITLE
Add optional port

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
   -h, --help     output usage information
   -s, --server   watch file and server changes. This overrides -w and -o.
   -w, --watch    watch markdown file and convert on changes
+  -p, --port     optional TCP port to start the server at, defaults to 9999
   -o, --output   optional file path for output. stdout is used by default.
                  required when using --watch.
 ```

--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,7 @@ var server = require('./server')
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
     's': 'server',
+    'p': 'port',
     'w': 'watch',
     'o': 'output',
     'h': 'help'
@@ -24,6 +25,7 @@ if (!argv._.length || argv.help) {
     '  -h, --help     output usage information\n' +
     '  -s, --server   watch file and server changes. This overrides -w and -o.\n' +
     '  -w, --watch    watch markdown file and convert on changes\n' +
+    '  -p, --port     optional TCP port to start the server at, defaults to 9999\n' +
     '  -o, --output   optional file path for output. stdout is used by default.\n' +
     '                 required when using --watch.'
   return console.log(usage)
@@ -40,10 +42,12 @@ if (argv.server) {
     .watch(markdownPath, {persistent: true})
     .on('change', updateServerHTML)
 
+  var port = argv.port || 9999
+
   return updateServerHTML(function() {
-    server.listen(9999)
-    console.log('Preview now being served at http://localhost:9999')
-    opn('http://localhost:9999')
+    server.listen(port)
+    console.log('Preview now being served at http://localhost:' + port)
+    opn('http://localhost:' + port)
   })
 }
 


### PR DESCRIPTION
This patch adds `--port` option to start a server on a different port.

Useful for starting several servers for different projects.
