### PR TITLE
Work around patterns interpreted by String.prototype.replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(markdown, callback) {
     if (err) return callback(err)
 
     var body = marked(markdown)
-    var html = template.replace('{{markdown}}', body)
+    var html = template.split('{{markdown}}').join(body)
     var inlinedHtml = inlineStyles(html, __dirname)
 
     callback(null, inlinedHtml.toString())


### PR DESCRIPTION
This PR replaces `String.prototype.replace` with the combination of `String.prototype.split` and `Array.prototype.join` to work around patterns such as `$&` or `$$` or `$'` that are interpreted by `String.prototype.replace`, leading for example to this:

```
$ github-markdown-preview <(echo '$&') | tail -3
<article class="markdown-body"><p>{{markdown}}amp;</p>
</article>

```